### PR TITLE
Chore: eslint-formatting

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -26,7 +26,12 @@ module.exports = {
   },
   plugins: ['@typescript-eslint', 'react-hooks', 'react', 'prettier'],
   rules: {
-    'prettier/prettier': 'error',
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': [
       'warn',


### PR DESCRIPTION
## 내용
macOS와 Windows의 LF, CRLF 개행 문자 사용 차이 이슈로 예상
.eslintrc.cjs 파일을 수정하였습니다. 
'prettier/prettier' 규칙에서 'endOfLine' 옵션을 'auto'로 설정하면 Prettier가 파일을 자동으로 감지하고 해당 운영 체제의 개행 문자 형식을 사용하도록 설정됩니다. 
## 참고 사항
